### PR TITLE
【更新】增强SDIO传输稳定性

### DIFF
--- a/stm32_sdio.h
+++ b/stm32_sdio.h
@@ -126,7 +126,7 @@ extern "C" {
 #define HW_SDIO_TO_HOST                        (0x01U << 1)
 #define HW_SDIO_DPSM_ENABLE                    (0x01U << 0)
 
-#define HW_SDIO_DATATIMEOUT                    (0x00100000U)
+#define HW_SDIO_DATATIMEOUT                    (0xF0000000U)
 
 struct stm32_sdio
 {


### PR DESCRIPTION
1. 只支持传输，最小传输4字节
2. 去除流控
3. 等待数据全部发送完成后返回